### PR TITLE
Remove "Helpful Defines"

### DIFF
--- a/qmk_compiler.py
+++ b/qmk_compiler.py
@@ -20,9 +20,6 @@ API_URL = environ.get('API_URL', 'https://api.qmk.fm/')
 # The `keymap.c` template to use when a keyboard doesn't have its own
 DEFAULT_KEYMAP_C = """#include QMK_KEYBOARD_H
 
-// Helpful defines
-#define _______ KC_TRNS
-
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 __KEYMAP_GOES_HERE__
 };


### PR DESCRIPTION
KC_TRNS is already included in QMK_KEYBOARD_H and we shouldn't promote this by generating it. 