### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 WORKDIR /qmk_compiler
 COPY . /qmk_compiler
-RUN pip3 install -r requirements.txt
+RUN pip3 install --upgrade wheel && pip3 install -r requirements.txt
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 CMD ./bin/start_worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM qmkfm/base_container
 MAINTAINER Zach White <skullydazed@gmail.com>
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    redis-tools && rm -rf /var/lib/apt/lists/*
+    redis-tools clang && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /qmk_compiler
 COPY . /qmk_compiler


### PR DESCRIPTION
Assists in the resolution of qmk/qmk_web_stack#1

* upgrade version of wheel in pip to resolve bdist_wheel errors during pip install
* add clang to image, it's required for the API population script