### PR TITLE
Dynamically disable/enable MOUSE when compiling

### DIFF
--- a/qmk_compiler.py
+++ b/qmk_compiler.py
@@ -5,7 +5,6 @@ from os import chdir, mkdir, environ, path, remove
 from subprocess import check_output, CalledProcessError, STDOUT
 from time import strftime
 from traceback import format_exc
-from itertools import chain
 
 from rq import get_current_job
 from rq.decorators import job


### PR DESCRIPTION
Iterate through all the keycodes looking for mouse keys. If you find one then enable it in firmware. The only downside to this approach is if the firmware is too big you will not really be able to do anything other than remove the mouse key.