### PR TITLE
Fix git branch configuration

### DIFF
--- a/qmk_commands.py
+++ b/qmk_commands.py
@@ -9,18 +9,25 @@ from dhooks import Embed, Webhook
 import qmk_storage
 from qmk_errors import NoSuchKeyboardError
 
-CHIBIOS_GIT_BRANCH = os.environ.get('GIT_BRANCH', 'qmk')
+## Environment setup
+if 'GIT_BRANCH' in os.environ:
+    for key in 'CHIBIOS_GIT_BRANCH', 'CHIBIOS_CONTRIB_GIT_BRANCH', 'LUFA_GIT_BRANCH', 'QMK_GIT_BRANCH':
+        if key not in os.environ:
+            os.environ[key] = os.environ['GIT_BRANCH']
+
+## Constants
+CHIBIOS_GIT_BRANCH = os.environ.get('CHIBIOS_GIT_BRANCH', 'qmk')
 CHIBIOS_GIT_URL = os.environ.get('CHIBIOS_GIT_URL', 'https://github.com/qmk/ChibiOS')
-CHIBIOS_CONTRIB_GIT_BRANCH = os.environ.get('GIT_BRANCH', 'qmk')
+CHIBIOS_CONTRIB_GIT_BRANCH = os.environ.get('CHIBIOS_CONTRIB_GIT_BRANCH', 'qmk')
 CHIBIOS_CONTRIB_GIT_URL = os.environ.get('CHIBIOS_CONTRIB_GIT_URL', 'https://github.com/qmk/ChibiOS-Contrib')
 DISCORD_WARNING_SENT = False
 DISCORD_WEBHOOK_URL = os.environ.get('DISCORD_WEBHOOK_URL')
 DISCORD_WEBHOOK_INFO_URL = os.environ.get('DISCORD_WEBHOOK_INFO_URL', DISCORD_WEBHOOK_URL)
 DISCORD_WEBHOOK_WARNING_URL = os.environ.get('DISCORD_WEBHOOK_WARNING_URL', DISCORD_WEBHOOK_URL)
 DISCORD_WEBHOOK_ERROR_URL = os.environ.get('DISCORD_WEBHOOK_ERROR_URL', DISCORD_WEBHOOK_URL)
-LUFA_GIT_BRANCH = os.environ.get('GIT_BRANCH', 'master')
+LUFA_GIT_BRANCH = os.environ.get('LUFA_GIT_BRANCH', 'master')
 LUFA_GIT_URL = os.environ.get('LUFA_GIT_URL', 'https://github.com/qmk/lufa')
-QMK_GIT_BRANCH = os.environ.get('GIT_BRANCH', 'master')
+QMK_GIT_BRANCH = os.environ.get('QMK_GIT_BRANCH', 'master')
 QMK_GIT_URL = os.environ.get('QMK_GIT_URL', 'https://github.com/qmk/qmk_firmware.git')
 ZIP_EXCLUDES = {
     'qmk_firmware': ('qmk_firmware/.build/*', 'qmk_firmware/.git/*', 'qmk_firmware/lib/chibios/.git', 'qmk_firmware/lib/chibios-contrib/.git'),
@@ -35,6 +42,7 @@ severities = {
 }
 
 
+## Helper functions
 def discord_msg(severity, message, include_icon=True):
     """Send a simple text message to discord.
     """


### PR DESCRIPTION
ChibiOS on the API was using the wrong branch (`qmk`) because the branch handling was incorrect. This fixes the logic so we can use the proper branch on the API.