### PR TITLE
Support V-USB as a submodule

### DIFF
--- a/qmk_commands.py
+++ b/qmk_commands.py
@@ -12,7 +12,7 @@ from qmk_errors import NoSuchKeyboardError
 
 ## Environment setup
 if 'GIT_BRANCH' in os.environ:
-    for key in 'CHIBIOS_GIT_BRANCH', 'CHIBIOS_CONTRIB_GIT_BRANCH', 'LUFA_GIT_BRANCH', 'QMK_GIT_BRANCH':
+    for key in 'CHIBIOS_GIT_BRANCH', 'CHIBIOS_CONTRIB_GIT_BRANCH', 'LUFA_GIT_BRANCH', 'VUSB_GIT_BRANCH', 'QMK_GIT_BRANCH':
         if key not in os.environ:
             os.environ[key] = os.environ['GIT_BRANCH']
 
@@ -30,6 +30,8 @@ CHIBIOS_CONTRIB_GIT_BRANCH = os.environ.get('CHIBIOS_CONTRIB_GIT_BRANCH', 'qmk')
 CHIBIOS_CONTRIB_GIT_URL = os.environ.get('CHIBIOS_CONTRIB_GIT_URL', 'https://github.com/qmk/ChibiOS-Contrib')
 LUFA_GIT_BRANCH = os.environ.get('LUFA_GIT_BRANCH', 'master')
 LUFA_GIT_URL = os.environ.get('LUFA_GIT_URL', 'https://github.com/qmk/lufa')
+VUSB_GIT_BRANCH = os.environ.get('VUSB_GIT_BRANCH', 'master')
+VUSB_GIT_URL = os.environ.get('VUSB_GIT_URL', 'https://github.com/obdev/v-usb')
 
 ZIP_EXCLUDES = {
     'qmk_firmware': ('qmk_firmware/.build/*', 'qmk_firmware/.git/*', 'qmk_firmware/lib/chibios/.git', 'qmk_firmware/lib/chibios-contrib/.git'),
@@ -144,6 +146,12 @@ def checkout_lufa():
     """Do whatever is needed to get the latest version of LUFA.
     """
     checkout_submodule('lufa', LUFA_GIT_URL, LUFA_GIT_BRANCH)
+
+
+def checkout_vusb():
+    """Do whatever is needed to get the latest version of V-USB.
+    """
+    checkout_submodule('vusb', VUSB_GIT_URL, VUSB_GIT_BRANCH)
 
 
 def git_clone(git_url=QMK_GIT_URL, git_branch=QMK_GIT_BRANCH):

--- a/qmk_commands.py
+++ b/qmk_commands.py
@@ -31,7 +31,7 @@ CHIBIOS_CONTRIB_GIT_URL = os.environ.get('CHIBIOS_CONTRIB_GIT_URL', 'https://git
 LUFA_GIT_BRANCH = os.environ.get('LUFA_GIT_BRANCH', 'master')
 LUFA_GIT_URL = os.environ.get('LUFA_GIT_URL', 'https://github.com/qmk/lufa')
 VUSB_GIT_BRANCH = os.environ.get('VUSB_GIT_BRANCH', 'master')
-VUSB_GIT_URL = os.environ.get('VUSB_GIT_URL', 'https://github.com/obdev/v-usb')
+VUSB_GIT_URL = os.environ.get('VUSB_GIT_URL', 'https://github.com/qmk/v-usb')
 
 ZIP_EXCLUDES = {
     'qmk_firmware': ['qmk_firmware/.build/*', 'qmk_firmware/.git/*', 'qmk_firmware/lib/chibios/.git', 'qmk_firmware/lib/chibios-contrib/.git'],

--- a/qmk_compiler.py
+++ b/qmk_compiler.py
@@ -11,7 +11,7 @@ from rq.decorators import job
 
 import qmk_redis
 import qmk_storage
-from qmk_commands import checkout_qmk, find_firmware_file, store_source, checkout_chibios, checkout_lufa, write_version_txt
+from qmk_commands import checkout_qmk, find_firmware_file, store_source, checkout_chibios, checkout_lufa, checkout_vusb, write_version_txt
 from qmk_redis import redis
 
 API_URL = environ.get('API_URL', 'https://api.qmk.fm/')
@@ -136,6 +136,8 @@ def compile_firmware(keyboard, keymap, layout, layers):
             checkout_lufa()
             if kb_data['protocol'] == 'ChibiOS':
                 checkout_chibios()
+        elif kb_data['protocol'] == 'V-USB':
+            checkout_vusb()
 
         # Write the keymap file
         with open(path.join('qmk_firmware', keymap_json_file), 'w') as fd:


### PR DESCRIPTION
This adds the necessary logic to checkout the V-USB Git repo when it becomes a submodule (https://github.com/qmk/qmk_firmware/pull/8321). Probably these will need to be merged in unison.