### PR TITLE
Clone into passed repo name

### DIFF
--- a/qmk_commands.py
+++ b/qmk_commands.py
@@ -127,9 +127,9 @@ def checkout_qmk(skip_cache=False, require_cache=False):
         rmtree('qmk_firmware')
 
     if require_cache:
-        fetch_source(repo_name(QMK_GIT_URL))
-    elif skip_cache or not fetch_source(repo_name(QMK_GIT_URL)):
-        git_clone(QMK_GIT_URL, QMK_GIT_BRANCH)
+        fetch_source('qmk_firmware')
+    elif skip_cache or not fetch_source('qmk_firmware'):
+        git_clone('qmk_firmware', QMK_GIT_URL, QMK_GIT_BRANCH)
 
 
 def checkout_submodule(name, url, branch):
@@ -141,7 +141,7 @@ def checkout_submodule(name, url, branch):
         rmtree(name)
 
     if not fetch_source(name):
-        git_clone(url, branch)
+        git_clone(name, url, branch)
 
     os.chdir('../..')
 
@@ -166,15 +166,14 @@ def checkout_vusb():
     checkout_submodule('vusb', VUSB_GIT_URL, VUSB_GIT_BRANCH)
 
 
-def git_clone(git_url=QMK_GIT_URL, git_branch=QMK_GIT_BRANCH):
+def git_clone(repo, git_url, git_branch):
     """Clone a git repo.
     """
-    repo = repo_name(git_url)
     zipfile_name = repo + '.zip'
     command = ['git', 'clone', '--single-branch', '-b', git_branch, git_url, repo]
 
     try:
-        logging.debug('Cloning qmk_firmware: %s', ' '.join(command))
+        logging.debug('Cloning repository: %s', ' '.join(command))
         check_output(command, stderr=STDOUT, universal_newlines=True)
         os.chdir(repo)
         write_version_txt()
@@ -303,17 +302,6 @@ def memoize(obj):
         return cache[key]
 
     return memoizer
-
-
-def repo_name(git_url):
-    """Returns the name a git URL will be cloned to.
-    """
-    name = git_url.split('/')[-1]
-
-    if name.endswith('.git'):
-        name = name[:-4]
-
-    return name.lower()
 
 
 def write_version_txt():

--- a/test_qmk_compiler.py
+++ b/test_qmk_compiler.py
@@ -105,24 +105,6 @@ def test_0013_git_hash():
     assert len(hash) == 40
 
 
-def test_0014_repo_name_qmk_firmware():
-    """Make sure that the qmk_firmware git url is reliably turned into qmk_firmware.
-    """
-    assert qmk_commands.repo_name('https://github.com/qmk/qmk_firmware.git') == 'qmk_firmware'
-
-
-def test_0015_repo_name_chibios():
-    """Make sure that the qmk_firmware git url is reliably turned into qmk_firmware.
-    """
-    assert qmk_commands.repo_name('https://github.com/qmk/ChibiOS.git') == 'chibios'
-
-
-def test_0016_repo_name_chibios_contrib():
-    """Make sure that the qmk_firmware git url is reliably turned into qmk_firmware.
-    """
-    assert qmk_commands.repo_name('https://github.com/qmk/ChibiOS-Contrib.git') == 'chibios-contrib'
-
-
 def test_0017_find_all_layouts_cluecard():
     """Make sure that update_kb_redis.find_all_layouts() can find the cluecard layout.
     """


### PR DESCRIPTION
`git_clone()` now takes a name of a directory to clone into. Removed `repo_name()`.