### PR TITLE
Remove check for Input Club boards

### DIFF
--- a/update_kb_redis.py
+++ b/update_kb_redis.py
@@ -466,8 +466,6 @@ def arm_processor_rules(keyboard_info, rules_mk):
     if keyboard_info['bootloader'] == 'unknown':
         if 'STM32' in keyboard_info['processor']:
             keyboard_info['bootloader'] = 'stm32-dfu'
-        elif keyboard_info.get('manufacturer') == 'Input Club':
-            keyboard_info['bootloader'] = 'kiibohd-dfu'
     keyboard_info['protocol'] = 'ChibiOS'
     if 'STM32' in keyboard_info['processor']:
         keyboard_info['platform'] = 'STM32'


### PR DESCRIPTION
This is no longer needed due to https://github.com/qmk/qmk_firmware/pull/10129.

https://api.qmk.fm/v1/keyboards/whitefox