### PR TITLE
Fix source downloads

### DIFF
--- a/qmk_compiler.py
+++ b/qmk_compiler.py
@@ -100,9 +100,6 @@ def compile_keymap(job, result):
         result['cmd'] = build_error.cmd
         result['output'] = build_error.output
 
-    finally:
-        store_firmware_metadata(job, result)
-
 
 @job('default', connection=redis, timeout=900)
 def compile_json(keyboard_keymap_data, source_ip=None, send_metrics=True, public_firmware=False):
@@ -237,6 +234,8 @@ def compile_json(keyboard_keymap_data, source_ip=None, send_metrics=True, public
 
         if send_metrics:
             graphyte.send(f'{base_metric}.{result["keyboard"]}.errors', 1)
+
+    store_firmware_metadata(job, result)
 
     return result
 

--- a/qmk_storage.py
+++ b/qmk_storage.py
@@ -30,7 +30,10 @@ __KEYMAP_GOES_HERE__
 };
 """
 
-# Objects we need to instaniate
+# Setup boto3 for talking to S3
+logging.getLogger('botocore').setLevel(logging.INFO)
+logging.getLogger('s3transfer').setLevel(logging.INFO)
+logging.getLogger('urllib3').setLevel(logging.INFO)
 session = boto3.session.Session()
 s3 = session.client(
     's3',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Metadata was being written to S3 too soon, breaking source downloads. This fixes that and turns off a bunch of log spam.

fixes https://github.com/qmk/qmk_api/issues/50