### PR TITLE
Remove explicit signature version from S3 config

### DIFF
--- a/qmk_storage.py
+++ b/qmk_storage.py
@@ -41,7 +41,6 @@ s3 = session.client(
     endpoint_url=S3_HOST,
     aws_access_key_id=S3_ACCESS_KEY,
     aws_secret_access_key=S3_SECRET_KEY,
-    config=botocore.client.Config(signature_version='s3'),
 )
 
 # Check to see if S3 is working, and if not print an error in the log.


### PR DESCRIPTION
MinIO on qmk_web_stack does not like `s3` anymore, although it does still support both v2 and v4 (with v4 being default apparently), as does DO.