### PR TITLE
Don't store firmware source for "public firmware"

### DIFF
--- a/qmk_compiler.py
+++ b/qmk_compiler.py
@@ -196,8 +196,11 @@ def compile_json(keyboard_keymap_data, source_ip=None, send_metrics=True, public
         storage_start_time = time()
         store_firmware_binary(result)
         chdir('..')
-        store_firmware_source(result)
-        remove(result['source_archive'])
+
+        if not public_firmware:
+            store_firmware_source(result)
+            remove(result['source_archive'])
+
         storage_time = time() - storage_start_time
 
         # Send metrics about this build


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Seems like the only thing that sets `public_firmware` to true is api_tasks. We don't need the qmk_firmware source for those jobs, it just takes up time, cycles and S3 space.
