### PR TITLE
Remove temp source zip in store_source instead of compile_json

### DIFF
--- a/qmk_commands.py
+++ b/qmk_commands.py
@@ -165,6 +165,7 @@ def store_source(zipfile_name, directory, storage_directory):
         os.chdir(orig_cwd)
 
     qmk_storage.save_file(str(zipfile_output), os.path.join(storage_directory, zipfile_name))
+    os.remove(zipfile_output)
 
     return True
 

--- a/qmk_compiler.py
+++ b/qmk_compiler.py
@@ -200,7 +200,6 @@ def compile_json(keyboard_keymap_data, source_ip=None, send_metrics=True, public
 
         if not public_firmware:
             store_firmware_source(result)
-            remove(result['source_archive'])
 
         storage_time = time() - storage_start_time
 


### PR DESCRIPTION
Not sure how to spin up an instance of this, so it's untested in context, but this should allow json compilation via Configurator to return successes instead of always erroring. Compilations that I've tested result in this stacktrace:

```
Traceback (most recent call last):
  File "./qmk_compiler.py", line 203, in compile_json
    remove(result['source_archive'])
FileNotFoundError: [Errno 2] No such file or directory: 'qmk_firmware-planck-rev6_drop-jack.zip'
```