### PR TITLE
Switch to yplan geoip packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ flake8
 graphyte
 rq
 pygments
-python-geoip-python3
-python-geoip-geolite2
+python-geoip-yplan
+python-geoip-geolite2-yplan
 pytest
 pytz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

Avoids the file collision due to python-geoip and python-geoip-python3 both being installed, and prevents the following stack trace when running on local webstack:

```
Traceback (most recent call last):
  File "./qmk_compiler.py", line 224, in compile_json
    ip_location = geolite2.lookup(source_ip)
  File "/usr/local/lib/python3.9/dist-packages/geoip.py", line 364, in lookup
    return self._get_actual_db().lookup(ip_addr)
  File "/usr/local/lib/python3.9/dist-packages/geoip.py", line 350, in _get_actual_db
    rv = self._load_database()
  File "/usr/local/lib/python3.9/dist-packages/geoip.py", line 342, in _load_database
    return mod.loader(self, sys.modules[__name__])
  File "/usr/local/lib/python3.9/dist-packages/_geoip_geolite2/__init__.py", line 9, in loader
    return mod.open_database(filename)
  File "/usr/local/lib/python3.9/dist-packages/geoip.py", line 508, in open_database
    md = _read_mmdb_metadata(buf)
  File "/usr/local/lib/python3.9/dist-packages/geoip.py", line 381, in _read_mmdb_metadata
    offset = buf.rfind(MMDB_METADATA_START,
TypeError: a bytes-like object is required, not 'str'
```